### PR TITLE
Apply string cast for the sha1 parameter

### DIFF
--- a/src/Infrastructure/Transport/FileWatcherFactory.php
+++ b/src/Infrastructure/Transport/FileWatcherFactory.php
@@ -26,7 +26,7 @@ final class FileWatcherFactory implements TransportFactoryInterface
                 $dsn->directory,
                 $this->gitDirectoriesLocation
                     ->sub('file-watcher-git')
-                    ->sub(\sha1($dsn->directory->path) . '.git'),
+                    ->sub(\sha1((string) $dsn->directory->path) . '.git'),
                 $dsn->timeout
             ),
             $dsn->backOffTime


### PR DESCRIPTION
# Changed log

- To avoid passing the `null` to the parameter #0 in the `sha1` function, it should use the cast string approach to resolved that.
   Otherwise it will present the following message when passing the `null` to the `sha1` function:

```
ERROR  sha1(): Passing null to parameter #1 ($string) of type string is deprecated
```